### PR TITLE
Update --reload docs to clarify when it can be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In this context, "Cython-based" means the following:
 Moreover, "optional extras" means that:
 
 - the websocket protocol will be handled by `websockets` (should you want to use `wsproto` you'd need to install it manually) if possible.
-- the `--reloader` flag in development mode will use `watchgod`.
+- the `--reload` flag in development mode will use `watchgod`.
 - windows users will have `colorama` installed for the colored logs.
 - `python-dotenv` will be installed should you want to use the `--env-file` option.
 - `PyYAML` will be installed to allow you to provide a `.yaml` file to `--log-config`, if desired.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -31,9 +31,13 @@ Options:
   --host TEXT                     Bind socket to this host.  [default:
                                   127.0.0.1]
   --port INTEGER                  Bind socket to this port.  [default: 8000]
-  --uds TEXT                      Bind to a UNIX domain socket.
+  --uds TEXT                      Bind to a UNIX domain socket. Not valid
+                                  with --reload.
   --fd INTEGER                    Bind to socket from this file descriptor.
-  --reload                        Enable auto-reload.
+                                  Not valid with --reload.
+  --reload                        Enable auto-reload. Use only during
+                                  development and if listening on a network
+                                  socket.
   --reload-dir TEXT               Set reload directories explicitly, instead
                                   of using the current working directory.
   --workers INTEGER               Number of worker processes. Defaults to the


### PR DESCRIPTION
The `--reload` option is incompatible with the `--uds` and `--fd` options. This can be surprising
to developers that are trying to replicate production deployment settings in their development
environment.

This simply adds some notes to the deployment documentation to let people know about this
ahead of time.

See #368 and #586.